### PR TITLE
Contract feat

### DIFF
--- a/Cross-Chain-Atomic-Swap/contracts/Cross-Chain-Atomic-Swap.clar
+++ b/Cross-Chain-Atomic-Swap/contracts/Cross-Chain-Atomic-Swap.clar
@@ -150,3 +150,74 @@
       (map-get? swaps { swap-id: swap-id }))) required)
   )
 )
+
+;; Check if participant count is under the limit
+(define-private (is-participant-count-valid (count uint))
+  (< count MAX-PARTICIPANTS-PER-MIXER)
+)
+
+;; Simulate ZKP verification
+;; In a real implementation, this would connect to a ZKP verification system
+(define-private (verify-zk-proof (proof-data (buff 1024)) (swap-details (buff 256)))
+  ;; This is a simplified stand-in for actual ZK proof verification
+  ;; In production, this would validate the cryptographic proof
+  (begin
+    ;; Check if the proof data is not empty (simplified verification)
+    (not (is-eq proof-data 0x))
+  )
+)
+
+;; Claim a swap using the hash preimage
+(define-public (claim-swap (swap-id (buff 32)) (preimage (buff 32)))
+  (let (
+    (swap (unwrap! (map-get? swaps { swap-id: swap-id }) (err ERR-SWAP-NOT-FOUND)))
+    (claimer tx-sender)
+  )
+    ;; Validation checks
+    (asserts! (is-eq claimer (get participant swap)) (err ERR-UNAUTHORIZED))
+    (asserts! (not (get claimed swap)) (err ERR-ALREADY-CLAIMED))
+    (asserts! (not (get refunded swap)) (err ERR-INVALID-REFUND))
+    (asserts! (verify-hash preimage (get hash-lock swap)) (err ERR-INVALID-HASH))
+    (asserts! (is-timelock-valid (get time-lock swap)) (err ERR-TIMELOCK-EXPIRED))
+    (asserts! (not (is-swap-expired (get expiration-height swap))) (err ERR-SWAP-EXPIRED))
+    
+    ;; For multi-sig swaps, verify we have enough signatures
+    (if (> (get multi-sig-required swap) u1)
+      (asserts! (verify-multi-sig swap-id (get multi-sig-required swap) (get multi-sig-provided swap)) 
+        (err ERR-INVALID-SIGNATURE))
+      true
+    )
+    
+    ;; Update the swap to claimed status
+    (map-set swaps
+      { swap-id: swap-id }
+      (merge swap { claimed: true })
+    )
+    
+    ;; Return success
+    (ok true)
+  )
+)
+
+;; Refund an expired or unclaimed swap
+(define-public (refund-swap (swap-id (buff 32)))
+  (let (
+    (swap (unwrap! (map-get? swaps { swap-id: swap-id }) (err ERR-SWAP-NOT-FOUND)))
+    (refunder tx-sender)
+  )
+    ;; Validation checks
+    (asserts! (is-eq refunder (get initiator swap)) (err ERR-UNAUTHORIZED))
+    (asserts! (not (get claimed swap)) (err ERR-ALREADY-CLAIMED))
+    (asserts! (not (get refunded swap)) (err ERR-INVALID-REFUND))
+    (asserts! (is-swap-expired (get expiration-height swap)) (err ERR-TIMELOCK-ACTIVE))
+    
+    ;; Update the swap to refunded status
+    (map-set swaps
+      { swap-id: swap-id }
+      (merge swap { refunded: true })
+    )
+    
+    ;; Return success
+    (ok true)
+  )
+)

--- a/Cross-Chain-Atomic-Swap/contracts/Cross-Chain-Atomic-Swap.clar
+++ b/Cross-Chain-Atomic-Swap/contracts/Cross-Chain-Atomic-Swap.clar
@@ -50,3 +50,47 @@
     protocol-fee: uint
   }
 )
+
+;; Stores ZK proofs for confidential transactions
+(define-map confidential-proofs
+  { swap-id: (buff 32) }
+  {
+    proof-data: (buff 1024),
+    verified: bool,
+    verification-time: uint
+  }
+)
+
+;; Tracks signers for multi-signature swaps
+(define-map multi-sig-approvals
+  { swap-id: (buff 32), signer: principal }
+  { approved: bool, signature-time: uint }
+)
+
+;; Stores mixing pools for enhanced privacy
+(define-map mixing-pools
+  { pool-id: (buff 32) }
+  {
+    total-amount: uint,
+    participant-count: uint,
+    min-amount: uint,
+    max-amount: uint,
+    activation-threshold: uint,
+    active: bool,
+    creation-height: uint,
+    execution-delay: uint,
+    execution-window: uint
+  }
+)
+
+;; Tracks participants in mixing pools
+(define-map mixer-participants
+  { pool-id: (buff 32), participant-id: uint }
+  {
+    participant: principal,
+    amount: uint,
+    blinded-output-address: (buff 64),
+    joined-height: uint,
+    withdrawn: bool
+  }
+)

--- a/Cross-Chain-Atomic-Swap/contracts/Cross-Chain-Atomic-Swap.clar
+++ b/Cross-Chain-Atomic-Swap/contracts/Cross-Chain-Atomic-Swap.clar
@@ -1,3 +1,52 @@
-
 ;; title: Cross-Chain-Atomic-Swap
 
+;; Error codes
+(define-constant ERR-UNAUTHORIZED u1)
+(define-constant ERR-SWAP-NOT-FOUND u2)
+(define-constant ERR-ALREADY-CLAIMED u3)
+(define-constant ERR-NOT-CLAIMABLE u4)
+(define-constant ERR-TIMELOCK-ACTIVE u5)
+(define-constant ERR-TIMELOCK-EXPIRED u6)
+(define-constant ERR-INVALID-PROOF u7)
+(define-constant ERR-INVALID-SIGNATURE u8)
+(define-constant ERR-INVALID-HASH u9)
+(define-constant ERR-INSUFFICIENT-FUNDS u10)
+(define-constant ERR-SWAP-EXPIRED u11)
+(define-constant ERR-INVALID-REFUND u12)
+(define-constant ERR-INVALID-PARTICIPANT u13)
+(define-constant ERR-MIXER-NOT-FOUND u14)
+(define-constant ERR-INVALID-FEE u15)
+(define-constant ERR-PARTICIPANT-LIMIT-REACHED u16)
+
+;; Configuration constants
+(define-constant MAX-TIMEOUT-BLOCKS u1000)
+(define-constant MIN-SWAP-AMOUNT u1000)
+(define-constant MAX-PARTICIPANTS-PER-MIXER u10)
+(define-constant MIXER-FEE-PERCENTAGE u5)  ;; 0.5%
+(define-constant PROTOCOL-FEE-PERCENTAGE u2)  ;; 0.2%
+(define-constant DEFAULT-QUORUM u2)  ;; Number of required signatures for multi-sig (out of 3)
+
+;; ----- Data Maps and Variables -----
+
+;; Tracks the status of each swap
+(define-map swaps
+  { swap-id: (buff 32) }
+  {
+    initiator: principal,
+    participant: principal,
+    amount: uint,
+    hash-lock: (buff 32),
+    time-lock: uint,
+    swap-token: (string-ascii 32),
+    target-chain: (string-ascii 32),
+    target-address: (buff 64),
+    claimed: bool,
+    refunded: bool,
+    multi-sig-required: uint,
+    multi-sig-provided: uint,
+    privacy-level: uint,
+    expiration-height: uint,
+    swap-fee: uint,
+    protocol-fee: uint
+  }
+)


### PR DESCRIPTION

### **Pull Request: Add Cross-Chain Atomic Swap Contract**

#### **Summary**

This PR introduces the initial implementation of a **Cross-Chain Atomic Swap** smart contract written in Clarity. The contract facilitates atomic asset swaps between different blockchains with optional privacy enhancements and multi-signature capabilities.

---

### **Key Features**

#### ✅ **Swap Management**

* `swaps` map tracks individual swap agreements between an initiator and a participant.
* Supports:

  * **Hash time-locked contracts (HTLC)**
  * **Multi-sig enforcement**
  * **Swap expiration and refund logic**

#### 🔐 **Security & Access Control**

* Multiple error codes (`ERR-*`) defined for robust error handling and access control.
* Access validation for:

  * Authorized claimer/refunder
  * Valid hash preimage
  * Expiry and time-lock checks
  * Signature quorum (for multi-sig)

#### 🔁 **Claim & Refund**

* **`claim-swap`**: Allows the participant to claim the swap by providing a valid preimage before expiration.
* **`refund-swap`**: Enables the initiator to refund if the swap expires unclaimed.

#### 🔒 **Zero-Knowledge Proofs (ZKP) Integration (Placeholder)**

* `confidential-proofs` map introduced for storing ZK proof data for private swaps.
* Simplified internal function simulates ZKP verification (`verify-zk-proof`).

#### 👥 **Multi-Signature Support**

* Signer approvals tracked in `multi-sig-approvals`.
* Verification of provided vs required signatures enforced during `claim-swap`.

#### 🌀 **Mixing Pools**

* Pools managed through `mixing-pools` and `mixer-participants` maps.
* Limits on participant count and mixing conditions (fee, thresholds, activation).
* Privacy-enhancing blind address design included for mixers.

#### ⚙️ **Configurable Constants**

* Swap thresholds, timeouts, fees, and participant limits are configurable.
* Constants include:

  * `MAX-TIMEOUT-BLOCKS`, `MIN-SWAP-AMOUNT`
  * `MIXER-FEE-PERCENTAGE`, `PROTOCOL-FEE-PERCENTAGE`
  * `DEFAULT-QUORUM`, `MAX-PARTICIPANTS-PER-MIXER`

